### PR TITLE
fix: correct arguments for mini.notify

### DIFF
--- a/lua/copycat/init.lua
+++ b/lua/copycat/init.lua
@@ -23,7 +23,7 @@ local function notify(message, level)
     local success, mini_notify = pcall(require, "mini.notify")
     if success and mini_notify then
       local level_key = get_level_key(level)
-      mini_notify.add(message, level_key, opts)
+      mini_notify.add(message, level_key)
       return
     end
   end


### PR DESCRIPTION
The `mini.notify.add` function was being called with a table as the third argument, which was being interpreted as the `hl_group`. This parameter expects a string, which caused a Lua error.

This commit fixes the error by removing the incorrect third argument from the function call. The call now correctly passes only the message and the notification level.